### PR TITLE
Add GPRS page

### DIFF
--- a/content/gprs.md
+++ b/content/gprs.md
@@ -1,0 +1,30 @@
+---
+title: GRPS
+description: >
+  Connecting to the Internet over the EMF GSM network
+---
+
+GPRS is experimentally available on the EMF GSM network, and any APN should work (`internet` is fine).
+
+# WAP Gateway
+
+**The WAP gateway is not hosted by the EMF GSM team, and is hosted by [Billy](https://billy.wales).**
+
+For devices that need a WAP Gateway (such as the Nokia 6310i and Nokia 6100), a third party of Kannel is available at `129.151.64.135`.
+The following steps are written with a Nokia device in mind, but should be useful for anyone trying to connect with the WAP gateway.
+
+1. Press Menu, select Services, and Settings.
+2. Select Active service settings.
+3. Scroll to the set you would like to edit and activate, and press *Activate*.
+4. Select *Edit active service settings*, and enter the following information:
+    - Settings' name: "EMF" or similar name.
+    - Homepage: `http://wap.billy.wales` (or similar WML homepage)
+    - Session Mode: Permanent
+    - Connection Security: Off
+    - Data Bearer: GPRS
+    - GPRS Connection: When needed (or Always, but this may drain battery!)
+    - GPRS access point: internet
+    - IP address: `129.151.64.135`
+    - Authentication Type: Normal
+    - Login Type: Automatic
+    - User name / password: (leave blank)


### PR DESCRIPTION
As discussed in IRC, here is the GPRS page :)

I've provided some steps on how to connect with an older Nokia device (I based it off the 6310i manual, but other Nokia manuals of the time have similar information); I do not expect my Kannel gateway to fall over any time soon, but my Kannel config for future reference is as follows:

```
#
# Sample configuration file for Kannel bearerbox on Debian.
# See the documentation for explanations of fields.
#

# HTTP administration is disabled by default. Make sure you set the
# password if you enable it.

group = core
admin-port = 13000
admin-password = Snip!
admin-deny-ip = "*.*.*.*"
admin-allow-ip = "127.0.0.1"
wapbox-port = 13002
wdp-interface-name = "*"
log-file = "/var/log/kannel/bearerbox.log"
box-deny-ip = "*.*.*.*"
box-allow-ip = "127.0.0.1"

group = wapbox
bearerbox-host = localhost
log-file = "/var/log/kannel/wapbox.log"
access-log = "/var/log/kannel/access.log"
device-home = "http://wap.billy.wales"
# Show the user errors as a WML deck!
smart-errors = true

# Enable WTLS on this server.
group = wtls
certificate-file = /etc/kannel/server.crt
privatekey-file = /etc/kannel/server.key
```